### PR TITLE
Filter hlf cards

### DIFF
--- a/HalfMagicProximity/App.cs
+++ b/HalfMagicProximity/App.cs
@@ -4,11 +4,11 @@
     {
         // ARGTODO: Pull from config
         const string SCRYFALL_PATH = "D:\\Personal Files\\Docs\\Magic\\HLF Proximity\\oracle-cards-20220423210218.json";
+        const bool DEBUG = true;
 
         static void Main(string[] args)
         {
-            // ARGTODO: Pull from config
-            Logger.IsDebugEnabled = true;
+            Logger.IsDebugEnabled = DEBUG;
 
             CardManager cardManager = new CardManager();
 

--- a/HalfMagicProximity/CardManager.cs
+++ b/HalfMagicProximity/CardManager.cs
@@ -50,6 +50,7 @@ namespace HalfMagicProximity
                     }
                     if (illegalSetCode) continue;
 
+                    // This card is legal, add it to the list
                     AddCard(node);
                 }
             }

--- a/HalfMagicProximity/CardManager.cs
+++ b/HalfMagicProximity/CardManager.cs
@@ -44,7 +44,7 @@ namespace HalfMagicProximity
                     {
                         if (GetProperty(node, CardProperty.SetCode).Contains(bannedCode))
                         {
-                            illegalSetCode = true; 
+                            illegalSetCode = true;
                             break;
                         }
                     }
@@ -54,7 +54,7 @@ namespace HalfMagicProximity
                     AddCard(node);
                 }
             }
-            
+
             if (cardCount == 0)
                 Logger.Error("No legal cards found!");
             else
@@ -71,7 +71,11 @@ namespace HalfMagicProximity
         // Extract the value of a json element's property as a string
         private string GetProperty(JsonElement element, CardProperty property)
         {
-            return element.GetProperty(PropertyString(property)).ToString();
+            string stringProperty = element.GetProperty(PropertyString(property)).ToString();
+
+            if (string.IsNullOrEmpty(stringProperty)) Logger.Error($"Card JSON missing {property} value.");
+
+            return stringProperty;
         }
 
         // Enum to facilitate accessing specific json card properties. Maintain alphabetization

--- a/HalfMagicProximity/CardManager.cs
+++ b/HalfMagicProximity/CardManager.cs
@@ -4,24 +4,100 @@ namespace HalfMagicProximity
 {
     public class CardManager
     {
+        // ARGTODO: Remove once actual card storage is implemented
+        private int cardCount = 0;
+
         public void ParseJson(string jsonPath)
         {
             // ARGTODO: Dummy proofing?
             using (Stream jsonStream = new FileStream(jsonPath, FileMode.Open, FileAccess.Read))
             using (JsonDocument jsonDoc = JsonDocument.Parse(jsonStream))
             {
-                // An array with all of the parsed card data
-                JsonElement scryfallData = jsonDoc.RootElement;
+                JsonElement root = jsonDoc.RootElement;
 
-                Logger.Info($"JSON Parsed. Found {scryfallData.GetArrayLength()} cards.");
+                if (root.GetArrayLength() == 0)
+                {
+                    Logger.Error($"No cards found in the Scryfall JSON: {jsonPath}");
+                    return;
+                }
 
-                CardData testCard = new CardData(
-                    scryfallData[0].GetProperty("name").ToString(),
-                    scryfallData[0].GetProperty("mana_cost").ToString(),
-                    CardFace.Front,
-                    CardLayout.Split);
+                Logger.Debug($"Filtering {root.GetArrayLength()} cards.");
+                for (int i = 0; i < root.GetArrayLength(); i++)
+                {
+                    JsonElement node = root[i];
 
-                Logger.Debug(testCard.GetDisplayString());
+                    // Filter cards not in the Adventure or Split layout
+                    string layout = GetProperty(node, CardProperty.Layout);
+                    if (layout != "adventure" && layout != "split") continue;
+
+                    // Filter out non black bordered cards
+                    if (GetProperty(node, CardProperty.BorderColor) != "black") continue;
+
+                    // Filter out cards from banned sets
+                    string[] bannedSetCodes =
+                    {
+                        "cmb", // Playtest Cards
+                        "htr", // Heroes of the Realm
+                    };
+                    bool illegalSetCode = false;
+                    foreach (string bannedCode in bannedSetCodes)
+                    {
+                        if (GetProperty(node, CardProperty.SetCode).Contains(bannedCode))
+                        {
+                            illegalSetCode = true; 
+                            break;
+                        }
+                    }
+                    if (illegalSetCode) continue;
+
+                    AddCard(node);
+                }
+            }
+            
+            if (cardCount == 0)
+                Logger.Error("No legal cards found!");
+            else
+                Logger.Info($"There are {cardCount} legal cards.");
+        }
+
+        private void AddCard(JsonElement jsonCard)
+        {
+            // ARGTODO: Pull relevant card data from JSON
+            cardCount++;
+            Logger.Debug($"{GetProperty(jsonCard, CardProperty.Name)} is legal.");
+        }
+
+        // Extract the value of a json element's property as a string
+        private string GetProperty(JsonElement element, CardProperty property)
+        {
+            return element.GetProperty(PropertyString(property)).ToString();
+        }
+
+        // Enum to facilitate accessing specific json card properties. Maintain alphabetization
+        private enum CardProperty
+        {
+            Artist,
+            BorderColor,
+            Layout,
+            ManaCost,
+            Name,
+            SetCode,
+        };
+
+        // Converts CardProperty enum to the string found in the scryfall json
+        private string PropertyString(CardProperty property)
+        {
+            switch (property)
+            {
+                case CardProperty.Name: return "name";
+                case CardProperty.ManaCost: return "mana_cost";
+                case CardProperty.Layout: return "layout";
+                case CardProperty.Artist: return "artist";
+                case CardProperty.BorderColor: return "border_color";
+                case CardProperty.SetCode: return "set";
+                default:
+                    Logger.Error($"Tried to access a card property that doesn't exist: {property}");
+                    return "";
             }
         }
     }


### PR DESCRIPTION
Successfully filtering out the 117 expected cards
- Must be adventure or split layout
- Must be black bordered
- Must not be from an illegal black border set (Heroes of the Realm and Playtest Cards at the moment)

[Trello Card](https://trello.com/c/6N9pLRIJ)