### PR TITLE
Generating proximity deck strings for each card

### DIFF
--- a/HalfMagicProximity/App.cs
+++ b/HalfMagicProximity/App.cs
@@ -11,6 +11,10 @@
                 CardManager cardManager = new CardManager();
 
                 cardManager.ParseJson(ConfigManager.ScryfallPath);
+
+                ProximityManager proximityManager = new ProximityManager(cardManager.Cards);
+
+                proximityManager.Run();
             }
             else
             {

--- a/HalfMagicProximity/CardData.cs
+++ b/HalfMagicProximity/CardData.cs
@@ -12,6 +12,10 @@
         public string Artist { get; private set; }
         public CardFace Face { get; private set; }
         public CardLayout Layout { get; private set; }
+        public CardData OtherFace { private get; set; }
+
+        public bool NeedsColorOverride => Color != OtherFace.Color;
+        public bool NeedsArtistOverride => Artist != OtherFace.Artist;
 
         public CardData(string name, string manaCost, string art, string artist, CardFace face, CardLayout layout)
         {
@@ -36,9 +40,9 @@
         /// <param name="manaCost"> The card's mana cost as a string</param>
         private void GetColorData(string manaCost)
         {
-            manaCost = manaCost.ToLower();
+            manaCost = manaCost.ToUpper();
 
-            char[] colors = { 'w', 'u', 'b', 'r', 'g' };
+            char[] colors = { 'W', 'U', 'B', 'R', 'G' };
 
             foreach (char color in colors)
             {
@@ -48,12 +52,24 @@
                 }
             }
 
+            Color = CorrectColorOrder(Color);
+
             ColorCount = Color.Length;
         }
 
-        public string GetDisplayString()
+        private string CorrectColorOrder(string color)
         {
-            return $"{Name} ({Layout} {Face})\n - {Color} ({ColorCount} color{(ColorCount > 1 ? "s" : "")})\n - Art File: {ArtFileName}\n - Artist: {Artist}";
+            // Some color pairs need to be reordered in order for proximity to recognize them properly
+            switch (color)
+            {
+                case "UG": return "GU";
+                case "WG": return "GW";
+                case "WR": return "RW";
+                default: return color;
+            }
         }
+
+        public string DisplayName => $"{Name} ({Layout} {Face})";
+        public string DisplayInfo => $"{DisplayName} | {Color} ({ColorCount} colors) | Artist: {Artist} | Art: '{ArtFileName}'";
     }
 }

--- a/HalfMagicProximity/CardManager.cs
+++ b/HalfMagicProximity/CardManager.cs
@@ -86,7 +86,7 @@ namespace HalfMagicProximity
                 cardFaces[i] = new CardData(
                     name,
                     GetCardProperty(jsonFaces[i], CardProperty.ManaCost),
-                    ArtFileName(name, face, artist),
+                    GenerateArtFileName(name, face, artist),
                     artist,
                     face,
                     layout);
@@ -102,7 +102,7 @@ namespace HalfMagicProximity
             if (cardFaces[0].NeedsArtistOverride) Logger.Debug($"{cardFaces[0].Name} needs an artist override: Front is '{cardFaces[0].Artist}', Back is '{cardFaces[1].Artist}'.");
         }
 
-        private string ArtFileName(string name, CardFace face, string artist)
+        private string GenerateArtFileName(string name, CardFace face, string artist)
         {
             if (face == CardFace.Front)
             {

--- a/HalfMagicProximity/CardManager.cs
+++ b/HalfMagicProximity/CardManager.cs
@@ -76,12 +76,14 @@ namespace HalfMagicProximity
 
             JsonElement jsonFaces = jsonCard.GetProperty("card_faces");
 
+            CardData[] cardFaces = new CardData[2];
+
             for (int i = 0; i < jsonFaces.GetArrayLength(); i++)
             {
                 CardFace face = (i == 0 ? CardFace.Front : CardFace.Back);
                 string artist = GetCardProperty(jsonFaces[i], CardProperty.Artist);
 
-                CardData card = new CardData(
+                cardFaces[i] = new CardData(
                     name,
                     GetCardProperty(jsonFaces[i], CardProperty.ManaCost),
                     ArtFileName(name, face, artist),
@@ -89,9 +91,15 @@ namespace HalfMagicProximity
                     face,
                     layout);
 
-                Cards.Add(card);
-                Logger.Debug($"Added {card.GetDisplayString()}");
+                Cards.Add(cardFaces[i]);
+                Logger.Debug($"Added {cardFaces[i].DisplayInfo}");
             }
+
+            cardFaces[0].OtherFace = cardFaces[1];
+            cardFaces[1].OtherFace = cardFaces[0];
+
+            if (cardFaces[0].NeedsColorOverride) Logger.Debug($"{cardFaces[0].Name} needs a color override: Front is {cardFaces[0].Color}, Back is {cardFaces[1].Color}.");
+            if (cardFaces[0].NeedsArtistOverride) Logger.Debug($"{cardFaces[0].Name} needs an artist override: Front is '{cardFaces[0].Artist}', Back is '{cardFaces[1].Artist}'.");
         }
 
         private string ArtFileName(string name, CardFace face, string artist)

--- a/HalfMagicProximity/ConfigManager.cs
+++ b/HalfMagicProximity/ConfigManager.cs
@@ -12,6 +12,7 @@ namespace HalfMagicProximity
         private static string defaultArtFileExtension = ".jpg";
 
         public static string ProxyRarityOverride;
+        public static bool IsProxyRarityOverrided => !string.IsNullOrEmpty(ProxyRarityOverride);
         private static string[] validRarities = { "common", "uncommon", "rare", "mythic" };
 
         public static bool DeleteBadFaces;

--- a/HalfMagicProximity/ProximityManager.cs
+++ b/HalfMagicProximity/ProximityManager.cs
@@ -6,7 +6,70 @@ using System.Threading.Tasks;
 
 namespace HalfMagicProximity
 {
-    internal class ProximityManager
+    public class ProximityManager
     {
+        private List<CardData> allCards;
+
+        public ProximityManager(List<CardData> allCards)
+        {
+            this.allCards = allCards ?? throw new ArgumentNullException(nameof(allCards));
+        }
+
+        public void Run()
+        {
+            Logger.Info("Beginning Proximity preparations.");
+
+            // Generate deck files
+            GenerateDeckFiles();
+
+            // Generate command string
+
+            // Verify that everything we need for proximity is present
+            
+            // Run proximity
+        }
+
+        private void GenerateDeckFiles()
+        {
+            // Create or open and clear file
+
+            // Add cards to file
+            foreach (var card in allCards)
+            {
+                GenerateCardString(card);
+            }
+        }
+
+        private const string OverrideTemplate = " --override=";
+
+        private string GenerateCardString(CardData card)
+        {
+            string cardString = $"1 {card.Name}";
+
+            // Add rarity override if one was specified in the config settings
+            if (ConfigManager.IsProxyRarityOverrided)
+                cardString += OverrideTemplate + "rarity:" + ConfigManager.ProxyRarityOverride;
+
+            // Add color override if faces have different colors
+            if (card.NeedsColorOverride)
+            {
+                cardString += OverrideTemplate + "colors:[\"" + card.Color + "\"]";
+                cardString += OverrideTemplate + "proximity.mtg.color_count:" + card.ColorCount;
+            }
+
+            if (card.NeedsArtistOverride)
+                cardString += OverrideTemplate + "artist:\"" + card.Artist + "\"";
+
+            if (card.Face == CardFace.Back)
+            {
+                string artPath = Path.Combine(ConfigManager.ProximityDirectory, "art", "back", card.ArtFileName).Replace("\\", "/");
+
+                cardString += OverrideTemplate + "image_uris.art_crop:\"\"file:///" + artPath + "\"\"";
+            }
+
+            Logger.Debug(cardString);
+
+            return cardString;
+        }
     }
 }

--- a/HalfMagicProximity/ProximityManager.cs
+++ b/HalfMagicProximity/ProximityManager.cs
@@ -19,7 +19,6 @@ namespace HalfMagicProximity
         {
             Logger.Info("Beginning Proximity preparations.");
 
-            // Generate deck files
             GenerateDeckFiles();
 
             // Generate command string
@@ -50,16 +49,18 @@ namespace HalfMagicProximity
             if (ConfigManager.IsProxyRarityOverrided)
                 cardString += OverrideTemplate + "rarity:" + ConfigManager.ProxyRarityOverride;
 
-            // Add color override if faces have different colors
+            // Add color overrides if faces have different colors
             if (card.NeedsColorOverride)
             {
                 cardString += OverrideTemplate + "colors:[\"" + card.Color + "\"]";
                 cardString += OverrideTemplate + "proximity.mtg.color_count:" + card.ColorCount;
             }
 
+            // Add artist override if faces have different artists
             if (card.NeedsArtistOverride)
                 cardString += OverrideTemplate + "artist:\"" + card.Artist + "\"";
 
+            // Front faces can automatically pull their art directly from the art folder or scryfall. Back faces need to be manually pointed to specific art crops
             if (card.Face == CardFace.Back)
             {
                 string artPath = Path.Combine(ConfigManager.ProximityDirectory, "art", "back", card.ArtFileName).Replace("\\", "/");


### PR DESCRIPTION
Each card needs the string it's going to use in the proximity decklist
- Generate appropriate overrides for color, artist, rarity and art
- Needed to make the cards aware of their other half for artist/color overrides
- Only want to override colors on specific cards so we maintain things like hybrid cards without needing specific intervention

[Trello Card](https://trello.com/c/S6JE3nAY)