### PR TITLE
Artist credit bugs

### DIFF
--- a/HalfMagicProximity/CardData.cs
+++ b/HalfMagicProximity/CardData.cs
@@ -10,12 +10,13 @@
         public int ColorCount { get; private set; }
         public string ArtFileName { get; private set; }
         public string Artist { get; private set; }
+        private bool manualArtist = false;
         public CardFace Face { get; private set; }
         public CardLayout Layout { get; private set; }
         public CardData OtherFace { private get; set; }
 
         public bool NeedsColorOverride => Color != OtherFace.Color;
-        public bool NeedsArtistOverride => Artist != OtherFace.Artist;
+        public bool NeedsArtistOverride => Artist != OtherFace.Artist || manualArtist;
 
         public CardData(string name, string manaCost, string art, string artist, CardFace face, CardLayout layout)
         {
@@ -62,11 +63,24 @@
             // Some color pairs need to be reordered in order for proximity to recognize them properly
             switch (color)
             {
-                case "UG": return "GU";
-                case "WG": return "GW";
-                case "WR": return "RW";
-                default: return color;
+                case "UG":
+                    Logger.Debug($"Correcting color of {DisplayName} from UG to GU.");
+                    return "GU";
+                case "WG":
+                    Logger.Debug($"Correcting color of {DisplayName} from WG to GW.");
+                    return "GW";
+                case "WR":
+                    Logger.Debug($"Correcting color of {DisplayName} from WR to RW.");
+                    return "RW";
+                default: 
+                    return color;
             }
+        }
+        public void CorrectArtist(string newArtist)
+        {
+            Logger.Debug($"Manually correcting artist of {DisplayName} from {Artist} to {newArtist} using config data.");
+            manualArtist = true;
+            Artist = newArtist;
         }
 
         public string DisplayName => $"{Name} ({Layout} {Face})";

--- a/HalfMagicProximity/CardData.cs
+++ b/HalfMagicProximity/CardData.cs
@@ -64,13 +64,13 @@
             switch (color)
             {
                 case "UG":
-                    Logger.Debug($"Correcting color of {DisplayName} from UG to GU.");
+                    Logger.Debug($"Correcting color of '{DisplayName}' from UG to GU.");
                     return "GU";
                 case "WG":
-                    Logger.Debug($"Correcting color of {DisplayName} from WG to GW.");
+                    Logger.Debug($"Correcting color of '{DisplayName}' from WG to GW.");
                     return "GW";
                 case "WR":
-                    Logger.Debug($"Correcting color of {DisplayName} from WR to RW.");
+                    Logger.Debug($"Correcting color of '{DisplayName}' from WR to RW.");
                     return "RW";
                 default: 
                     return color;
@@ -78,7 +78,7 @@
         }
         public void CorrectArtist(string newArtist)
         {
-            Logger.Debug($"Manually correcting artist of {DisplayName} from {Artist} to {newArtist} using config data.");
+            Logger.Debug($"Manually correcting artist of '{DisplayName}' from '{Artist}' to '{newArtist}'.");
             manualArtist = true;
             Artist = newArtist;
         }

--- a/HalfMagicProximity/CardData.cs
+++ b/HalfMagicProximity/CardData.cs
@@ -1,7 +1,7 @@
 ﻿namespace HalfMagicProximity
 {
-    public enum CardFace { Front, Back, };
-    public enum CardLayout { Split, Adventure, None};
+    public enum CardFace { Front, Back };
+    public enum CardLayout { Split, Adventure, None };
 
     public class CardData
     {

--- a/HalfMagicProximity/CardManager.cs
+++ b/HalfMagicProximity/CardManager.cs
@@ -108,10 +108,18 @@ namespace HalfMagicProximity
             cardFaces[1].OtherFace = cardFaces[0];
 
             if (cardFaces[0].NeedsColorOverride) 
-                Logger.Debug($"{cardFaces[0].Name} needs a color override: Front is {cardFaces[0].Color}, Back is {cardFaces[1].Color}.");
+                Logger.Debug($"'{cardFaces[0].Name}' needs a color override: Front is {cardFaces[0].Color}, Back is {cardFaces[1].Color}.");
 
             if (cardFaces[0].NeedsArtistOverride)
-                Logger.Debug($"{cardFaces[0].Name} needs an artist override: Front is '{cardFaces[0].Artist}', Back is '{cardFaces[1].Artist}'.");
+            {
+                string frontArtist = cardFaces[0].Artist;
+                string backArtist = cardFaces[1].Artist;
+
+                if (frontArtist == backArtist)
+                    Logger.Debug($"'{cardFaces[0].Name}' needs an artist override since it was manually corrected.");
+                else
+                    Logger.Debug($"'{cardFaces[0].Name}' needs an artist override: Front is '{cardFaces[0].Artist}', Back is '{cardFaces[1].Artist}'.");
+            }
         }
 
         private ManualArtistOverride CheckForManualArtistOverride(string name, CardFace face)
@@ -130,7 +138,6 @@ namespace HalfMagicProximity
             if (face == CardFace.Front)
             {
                 return name.Replace("/", "") + ConfigManager.ArtFileExtension;
-                //return $"{name.Replace("/", "")} ({artist}){ConfigManager.ArtFileExtension}";
             }
             else
             {

--- a/HalfMagicProximity/CardManager.cs
+++ b/HalfMagicProximity/CardManager.cs
@@ -72,6 +72,10 @@ namespace HalfMagicProximity
         private void AddCard(JsonElement jsonCard)
         {
             string name = GetCardProperty(jsonCard, CardProperty.Name);
+
+            // Only add cards in the debug card list if we're using that subset of cards
+            if (ConfigManager.UseDebugCardSubset && !ConfigManager.DebugCards.Contains(name.ToLower())) return;
+
             CardLayout layout = GetCardLayout(GetCardProperty(jsonCard, CardProperty.Layout));
 
             JsonElement jsonFaces = jsonCard.GetProperty("card_faces");
@@ -91,6 +95,11 @@ namespace HalfMagicProximity
                     face,
                     layout);
 
+                // Check for manual artist overrides and implement them
+                ManualArtistOverride manualArtistOverride = CheckForManualArtistOverride(name, face);
+                if (manualArtistOverride != null && face == manualArtistOverride.CardFace)
+                    cardFaces[i].CorrectArtist(manualArtistOverride.Artist);
+
                 Cards.Add(cardFaces[i]);
                 Logger.Debug($"Added {cardFaces[i].DisplayInfo}");
             }
@@ -98,15 +107,30 @@ namespace HalfMagicProximity
             cardFaces[0].OtherFace = cardFaces[1];
             cardFaces[1].OtherFace = cardFaces[0];
 
-            if (cardFaces[0].NeedsColorOverride) Logger.Debug($"{cardFaces[0].Name} needs a color override: Front is {cardFaces[0].Color}, Back is {cardFaces[1].Color}.");
-            if (cardFaces[0].NeedsArtistOverride) Logger.Debug($"{cardFaces[0].Name} needs an artist override: Front is '{cardFaces[0].Artist}', Back is '{cardFaces[1].Artist}'.");
+            if (cardFaces[0].NeedsColorOverride) 
+                Logger.Debug($"{cardFaces[0].Name} needs a color override: Front is {cardFaces[0].Color}, Back is {cardFaces[1].Color}.");
+
+            if (cardFaces[0].NeedsArtistOverride)
+                Logger.Debug($"{cardFaces[0].Name} needs an artist override: Front is '{cardFaces[0].Artist}', Back is '{cardFaces[1].Artist}'.");
+        }
+
+        private ManualArtistOverride CheckForManualArtistOverride(string name, CardFace face)
+        {
+            foreach(ManualArtistOverride artistOverride in ConfigManager.ManualArtistOverrides)
+            {
+                if (artistOverride.CardName == name.ToLower() && artistOverride.CardFace == face) 
+                    return artistOverride;
+            }
+
+            return null;
         }
 
         private string GenerateArtFileName(string name, CardFace face, string artist)
         {
             if (face == CardFace.Front)
             {
-                return $"{name.Replace("/", "")} ({artist}){ConfigManager.ArtFileExtension}";
+                return name.Replace("/", "") + ConfigManager.ArtFileExtension;
+                //return $"{name.Replace("/", "")} ({artist}){ConfigManager.ArtFileExtension}";
             }
             else
             {
@@ -120,7 +144,8 @@ namespace HalfMagicProximity
         {
             string stringProperty = element.GetProperty(PropertyString(property)).ToString();
 
-            if (string.IsNullOrEmpty(stringProperty)) Logger.Error($"Card JSON missing {property} value.");
+            if (string.IsNullOrEmpty(stringProperty)) 
+                Logger.Error($"Card JSON missing {property} value.");
 
             return stringProperty;
         }

--- a/HalfMagicProximity/ConfigManager.cs
+++ b/HalfMagicProximity/ConfigManager.cs
@@ -122,8 +122,18 @@ namespace HalfMagicProximity
                         JsonElement debugCardElement = configOptions.GetProperty("DebugCards");
                         for (int i = 0; i < debugCardElement.GetArrayLength(); i++)
                         {
-                            DebugCards.Add(debugCardElement[i].ToString().ToLower());
-                            Logger.Info($"Added {DebugCards[i]} to list of debug cards.");
+                            string debugCard = debugCardElement[i].ToString().ToLower();
+
+                            if (!debugCard.Contains("//"))
+                            {
+                                Logger.Warn($"Debug card '{debugCard}' does not have '//'. Please double check that you have the full card name.");
+                            }
+                            else
+                            {
+                                DebugCards.Add(debugCard);
+                                Logger.Info($"Added '{DebugCards.Last()}' to list of debug cards.");
+                            }
+
                         }
                     }
                     else
@@ -147,27 +157,28 @@ namespace HalfMagicProximity
                         }
                         else if (!card.Contains("//"))
                         {
-                            Logger.Warn($"Artist override '{card}' does not have '//'. Double check that you have the full card name.");
-                        }
-
-                        // Determine whether the card is a front or back face. Default to front
-                        CardFace face = CardFace.Front;
-                        string faceString = cardElement.GetProperty("face").ToString().ToLower();
-                        if (faceString == "back")
-                            face = CardFace.Back;
-                        else if (faceString != "front")
-                            Logger.Warn($"Manual artist override for '{card}' has its face improperly specified. Defaulting to 'front'.");
-
-                        // Determine the artist name to use
-                        string artist = cardElement.GetProperty("artist").ToString().ToLower();
-                        if (string.IsNullOrEmpty(artist))
-                        {
-                            Logger.Error($"Skipping artist override with no artist name!");
+                            Logger.Warn($"Artist override '{card}' does not have '//'. Please double check that you have the full card name.");
                             continue;
                         }
 
+                        // Determine the artist name to use
+                        string artist = cardElement.GetProperty("artist").ToString();
+                        if (string.IsNullOrEmpty(artist))
+                        {
+                            Logger.Error($"Skipping artist override for '{card}' with no artist name!");
+                            continue;
+                        }
+
+                        // Determine whether the card is a front or back face. Default to back
+                        CardFace face = CardFace.Back;
+                        string faceString = cardElement.GetProperty("face").ToString().ToLower();
+                        if (faceString == "front")
+                            face = CardFace.Front;
+                        else if (faceString != "back")
+                            Logger.Warn($"Manual artist override for '{card}' has its face improperly specified. Defaulting to 'Back'.");
+
                         ManualArtistOverrides.Add(new ManualArtistOverride(card, face, artist));
-                        Logger.Info($"Added '{ManualArtistOverrides[i].CardName}' to list of artist overrides.");
+                        Logger.Info($"Added '{ManualArtistOverrides.Last().CardName}' to list of artist overrides.");
                     }
                 }
             }

--- a/HalfMagicProximity/ProximityManager.cs
+++ b/HalfMagicProximity/ProximityManager.cs
@@ -24,8 +24,6 @@ namespace HalfMagicProximity
             // Run proximity
         }
 
-        private string[] testCards = { "Alive // Well", "Fae of Wishes // Granted", "Find // Finality", "Hide // Seek", "Road // Ruin", "Night // Day", "Fast // Furious" };
-
         private void GenerateDeckFiles()
         {
             // Create or open and clear file
@@ -40,10 +38,6 @@ namespace HalfMagicProximity
                     // Add cards to file
                     foreach (CardData card in allCards)
                     {
-                        // Skip most cards except for a small selection of test cards if we're debugging.
-                        // ARGTODO: This should probably not be here long term
-                        if (Logger.IsDebugEnabled && !testCards.Contains(card.Name)) continue;
-
                         string cardString = GenerateCardString(card);
                         byte[] cardBytes = new UTF8Encoding(true).GetBytes(cardString + Environment.NewLine);
 

--- a/HalfMagicProximity/ProximityManager.cs
+++ b/HalfMagicProximity/ProximityManager.cs
@@ -24,7 +24,7 @@ namespace HalfMagicProximity
             // Run proximity
         }
 
-        private string[] testCards = { "Alive // Well", "Fae of Wishes // Granted", "Find // Finality", "Hide // Seek", "Road // Ruin", "Night // Day" };
+        private string[] testCards = { "Alive // Well", "Fae of Wishes // Granted", "Find // Finality", "Hide // Seek", "Road // Ruin", "Night // Day", "Fast // Furious" };
 
         private void GenerateDeckFiles()
         {

--- a/HalfMagicProximity/hlfconfig.json
+++ b/HalfMagicProximity/hlfconfig.json
@@ -6,6 +6,20 @@
 		"ArtFileExtension": ".jpg",
 		"ProxyRarityOverride": "uncommon",
 		"DeleteBadFaces": false,
-		"IllegalSetCodes": [ "htr", "cmb" ]
+		"IllegalSetCodes": [ "htr", "cmb" ],
+		"UseDebugCardSubset": true,
+		"DebugCards": [ "Alive // Well", "Fae of Wishes // Granted", "Find // Finality", "Hide // Seek", "Road // Ruin", "Night // Day", "Fast // Furious", "Order of Midnight // Alter Fate" ],
+		"ManualArtistOverrides": [
+			{
+				"card": "Granted",
+				"face": "Back",
+				"artist": "Wylie Beckert"
+			},
+			{
+				"card": "Order of Midnight // Alter Fate",
+				"face": "Back",
+				"artist": "Seb McKinnon"
+			}
+		]
 	}
 }

--- a/HalfMagicProximity/hlfconfig.json
+++ b/HalfMagicProximity/hlfconfig.json
@@ -1,6 +1,6 @@
 {
 	"hlfOptions": {
-		"IsDebugEnabled": false,
+		"IsDebugEnabled": true,
 		"ScryfallPath": "D:\\Personal Files\\Docs\\Magic\\HalfMagic\\VS App\\oracle-cards-20220423210218.json",
 		"ProximityDirectory": "D:\\Personal Files\\Docs\\Magic\\HalfMagic\\VS App\\Proximity",
 		"ArtFileExtension": ".jpg",
@@ -8,17 +8,42 @@
 		"DeleteBadFaces": false,
 		"IllegalSetCodes": [ "htr", "cmb" ],
 		"UseDebugCardSubset": true,
-		"DebugCards": [ "Alive // Well", "Fae of Wishes // Granted", "Find // Finality", "Hide // Seek", "Road // Ruin", "Night // Day", "Fast // Furious", "Order of Midnight // Alter Fate" ],
+		"DebugCards": [ "Alive // Well", "Fae of Wishes // Granted", "Find // Finality", "Hide // Seek", "Road // Ruin", "Night // Day", "Fast // Furious", "Order of Midnight // Alter Fate", "Animating Faerie" ],
 		"ManualArtistOverrides": [
+			{
+				"card": "Fae of Wishes // Granted",
+				"face": "Back",
+				"artist": "Wylie Beckert"
+			},
+			{
+				"card": "Order of Midnight // Alter Fate",
+				"face": "",
+				"artist": "Seb McKinnon"
+			},
+			{
+				"card": "Hide // Seek",
+				"face": "Front",
+				"artist": "Zoltan Boros & Gabor Szikszai"
+			},
+			{
+				"card": "Hide // Seek",
+				"face": "Back",
+				"artist": "Zoltan Boros & Gabor Szikszai"
+			},
 			{
 				"card": "Granted",
 				"face": "Back",
 				"artist": "Wylie Beckert"
 			},
 			{
-				"card": "Order of Midnight // Alter Fate",
+				"card": "",
 				"face": "Back",
-				"artist": "Seb McKinnon"
+				"artist": "Aaron Miller"
+			},
+			{
+				"card": "Ardenvale Tactician // Dizzying Swoop",
+				"face": "",
+				"artist": ""
 			}
 		]
 	}

--- a/HalfMagicProximity/hlfconfig.json
+++ b/HalfMagicProximity/hlfconfig.json
@@ -8,17 +8,12 @@
 		"DeleteBadFaces": false,
 		"IllegalSetCodes": [ "htr", "cmb" ],
 		"UseDebugCardSubset": true,
-		"DebugCards": [ "Alive // Well", "Fae of Wishes // Granted", "Find // Finality", "Hide // Seek", "Road // Ruin", "Night // Day", "Fast // Furious", "Order of Midnight // Alter Fate", "Animating Faerie" ],
+		"DebugCards": [ "Alive // Well", "Fae of Wishes // Granted", "Find // Finality", "Hide // Seek", "Road // Ruin", "Night // Day", "Fast // Furious" ],
 		"ManualArtistOverrides": [
 			{
 				"card": "Fae of Wishes // Granted",
 				"face": "Back",
 				"artist": "Wylie Beckert"
-			},
-			{
-				"card": "Order of Midnight // Alter Fate",
-				"face": "",
-				"artist": "Seb McKinnon"
 			},
 			{
 				"card": "Hide // Seek",
@@ -29,21 +24,6 @@
 				"card": "Hide // Seek",
 				"face": "Back",
 				"artist": "Zoltan Boros & Gabor Szikszai"
-			},
-			{
-				"card": "Granted",
-				"face": "Back",
-				"artist": "Wylie Beckert"
-			},
-			{
-				"card": "",
-				"face": "Back",
-				"artist": "Aaron Miller"
-			},
-			{
-				"card": "Ardenvale Tactician // Dizzying Swoop",
-				"face": "",
-				"artist": ""
 			}
 		]
 	}


### PR DESCRIPTION
Fixed two bugs relating to artist credits by allowing the user to manually set artist overrides in the config file.
- [Back artist with ampersand name](https://trello.com/c/rXpetWoO): Can't do automatically, since some cards (Night // Day) genuinely have different artists per face and they're stored identically in the scryfall data.
- [Adventure backs credit front artists](https://trello.com/c/Mu3b62vT): Since there's no way to know where the back art came from, this has to be manually overridden on a case by case basis.

Additionally, added a list of debug cards to use that can be set in the config file. This makes testing easier since I don't have to generate all 234 cards each time.