### PR TITLE
Sketch template

### DIFF
--- a/HalfMagicProximity/App.cs
+++ b/HalfMagicProximity/App.cs
@@ -19,13 +19,13 @@ namespace HalfMagicProximity
                 ProximityManager proximityManager = new ProximityManager(cardManager.Cards);
                 ArtManager artManager = new ArtManager(cardManager.Cards);
 
+                // Generate the front faces of adventures and all split cards with the normal M15 template
                 proximityManager.Run(isSketch:false);
                 artManager.CleanProxies(isSketch: false);
+
+                // Generate the back faces of adventures with the sketch template
                 proximityManager.Run(isSketch:true);
                 artManager.CleanProxies(isSketch:true);
-
-                //if (ConfigManager.DeleteBadFaces)
-                //    artManager.CleanProxies();
 
                 TimeSpan elapsed = timer.Elapsed;
                 string elapsedString = string.Format("{0:00}:{1:00}.{2:00}", elapsed.Minutes, elapsed.Seconds, elapsed.Milliseconds / 10);

--- a/HalfMagicProximity/App.cs
+++ b/HalfMagicProximity/App.cs
@@ -19,10 +19,13 @@ namespace HalfMagicProximity
                 ProximityManager proximityManager = new ProximityManager(cardManager.Cards);
                 ArtManager artManager = new ArtManager(cardManager.Cards);
 
-                proximityManager.Run();
+                proximityManager.Run(isSketch:false);
+                artManager.CleanProxies(isSketch: false);
+                proximityManager.Run(isSketch:true);
+                artManager.CleanProxies(isSketch:true);
 
-                if (ConfigManager.DeleteBadFaces)
-                    artManager.CleanProxies();
+                //if (ConfigManager.DeleteBadFaces)
+                //    artManager.CleanProxies();
 
                 TimeSpan elapsed = timer.Elapsed;
                 string elapsedString = string.Format("{0:00}:{1:00}.{2:00}", elapsed.Minutes, elapsed.Seconds, elapsed.Milliseconds / 10);

--- a/HalfMagicProximity/ArtManager.cs
+++ b/HalfMagicProximity/ArtManager.cs
@@ -91,7 +91,8 @@ namespace HalfMagicProximity
                                 {
                                     if (cardData.Face == CardFace.Back && cardData.Layout == CardLayout.Adventure)
                                     {
-                                        deleteProxy = false;
+                                        // Ignore all adventure backs if we're not pulling sketches
+                                        deleteProxy = true;
                                         Logger.Trace(LogSource, $"Skipping normal proxy for adventure backs. Wait for a sketch proxy.");
                                     }
                                     else
@@ -123,10 +124,7 @@ namespace HalfMagicProximity
 
                                         if (File.Exists(goodProxyPath))
                                         {
-                                            if (isSketch)
-                                                Logger.Debug(LogSource, $"Good sketch proxy for {cardName} overwriting previous proxy in '{goodProxyPath}'.");
-                                            else
-                                                Logger.Debug(LogSource, $"Good proxy for {cardName} copied to '{goodProxyPath}'.");
+                                            Logger.Debug(LogSource, $"Good proxy for {cardName} copied to '{goodProxyPath}'.");
                                             goodProxyCount++;
                                         }
                                         else
@@ -154,8 +152,15 @@ namespace HalfMagicProximity
                             Logger.Trace(LogSource, $"Processed {processedCount} of {totalFileCount} potential proxies.");
                         }
 
-                        // Delete file once we're done with it to keep things clean for next run
-                        File.Delete(proxyFilePath);
+                        try
+                        {
+                            // Delete file once we're done with it to keep things clean for next run
+                            File.Delete(proxyFilePath);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error(LogSource, ex.Message);
+                        }
                     }
                     else
                     {

--- a/HalfMagicProximity/CardData.cs
+++ b/HalfMagicProximity/CardData.cs
@@ -28,6 +28,9 @@
         public bool NeedsArtistOverride => Artist != OtherFace.Artist || manualArtist;
         public bool NeedsWatermarkOverride => !string.IsNullOrEmpty(Watermark) || !string.IsNullOrEmpty(OtherFace.Watermark);
 
+        // All Adventure Backs (ie. the actual adventure spell) are generated with a different template from their fronts and split cards
+        public bool UseSketchTemplate => Face == CardFace.Back && Layout == CardLayout.Adventure;
+
         public CardData(string name, string manaCost, string art, string artist, CardFace face, CardLayout layout, string watermark)
         {
             if (string.IsNullOrEmpty(name))

--- a/HalfMagicProximity/CardData.cs
+++ b/HalfMagicProximity/CardData.cs
@@ -150,7 +150,7 @@
                 return false;
             }
 
-            Logger.Trace(namedLogSource, $"{DisplayName} validated succesfully. No issues detected.");
+            Logger.Trace(namedLogSource, $"{DisplayName} validated successfully. No issues detected.");
 
             return true;
         }

--- a/HalfMagicProximity/ConfigManager.cs
+++ b/HalfMagicProximity/ConfigManager.cs
@@ -14,7 +14,6 @@ namespace HalfMagicProximity
         public static string ProximityDirectory;
         public static string OutputDirectory;
 
-        public static bool DeleteBadFaces;
         public static bool UpdatesOnly;
 
         public static int MaxRetries;
@@ -65,7 +64,6 @@ namespace HalfMagicProximity
                     ParseOutputDirectory(configOptions);
 
                     // Boolean options
-                    ParseProxyCleanup(configOptions);
                     ParseUpdatesOnly(configOptions);
 
                     // Integer options
@@ -465,18 +463,6 @@ namespace HalfMagicProximity
             {
                 Logger.Debug(LogSource, $"Proxy rarity override pulled from config: '{ProxyRarityOverride}'.");
             }
-        }
-
-        /// <summary>
-        /// Determine whether we're cleaning up the generated proxies, or leaving them raw
-        /// </summary>
-        private static void ParseProxyCleanup(JsonElement configOptions)
-        {
-            DeleteBadFaces = configOptions.GetProperty("DeleteBadFaces").GetBoolean();
-            if (DeleteBadFaces)
-                Logger.Debug(LogSource, $"Bad proxy faces will be deleted once all proxies have been rendered.");
-            else
-                Logger.Warn(LogSource, $"Bad proxy faces will not be automatically deleted.");
         }
 
         /// <summary>

--- a/HalfMagicProximity/ProximityBatch.cs
+++ b/HalfMagicProximity/ProximityBatch.cs
@@ -268,7 +268,7 @@ namespace HalfMagicProximity
                 }
                 else
                 {
-                    Logger.Warn(namedLogSource, $"Batch already contains {card.DisplayName}");
+                    Logger.Trace(namedLogSource, $"Already rerendering {card.DisplayName}.");
                 }
             }
         }

--- a/HalfMagicProximity/ProximityBatch.cs
+++ b/HalfMagicProximity/ProximityBatch.cs
@@ -24,14 +24,16 @@ namespace HalfMagicProximity
 
         private string proximityFile;
         private string proximityPath => Path.Combine(ConfigManager.ProximityDirectory, proximityFile);
-        private string templateFile => "hlf.zip";
+        private const string hlfTemplateFile = "hlf.zip";
+        private const string sketchTemplateFile = "hlfsketch.zip";
+        private string templateFile;
         private string templatePath => Path.Combine(ConfigManager.ProximityDirectory, "templates", templateFile);
 
         public int CardCount { get; private set; }
         public bool IsFull => CardCount >= ConfigManager.BatchSize;
         public bool IsBatchFunctional => !string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(proximityFile) && CardCount > 0;
 
-        public ProximityBatch(ProximityManager manager, string name, string prox)
+        public ProximityBatch(ProximityManager manager, string name, string prox, bool isSketch)
         {
             this.manager = manager ?? throw new ArgumentNullException(nameof(manager));
 
@@ -44,6 +46,11 @@ namespace HalfMagicProximity
                 Logger.Error(namedLogSource, $"No proximity file provided. Unable to run proximity without the jar file!");
             else
                 proximityFile = prox;
+
+            if (isSketch)
+                templateFile = sketchTemplateFile;
+            else
+                templateFile = hlfTemplateFile;
 
             Logger.Trace(namedLogSource, $"Batch {this.name} successfully created.");
         }

--- a/HalfMagicProximity/ProximityBatch.cs
+++ b/HalfMagicProximity/ProximityBatch.cs
@@ -29,7 +29,8 @@ namespace HalfMagicProximity
         private string templateFile;
         private string templatePath => Path.Combine(ConfigManager.ProximityDirectory, "templates", templateFile);
 
-        public int CardCount { get; private set; }
+        public int CardCount => cards.Count;
+        private List<CardData> cards = new List<CardData>();
         public bool IsFull => CardCount >= ConfigManager.BatchSize;
         public bool IsBatchFunctional => !string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(proximityFile) && CardCount > 0;
 
@@ -160,11 +161,11 @@ namespace HalfMagicProximity
             // Check for the proximity template file
             if (File.Exists(templatePath))
             {
-                Logger.Trace(namedLogSource, $"Batch file '{templateFile}' is present.");
+                Logger.Trace(namedLogSource, $"Template '{templateFile}' is present.");
             }
             else
             {
-                Logger.Error(namedLogSource, $"Batch file not found: {templatePath}");
+                Logger.Error(namedLogSource, $"Template not found: {templatePath}");
 
                 return false;
             }
@@ -258,10 +259,17 @@ namespace HalfMagicProximity
 
             if (!string.IsNullOrEmpty(cardString))
             {
-                deckContents += cardString + Environment.NewLine;
-                CardCount++;
+                if (!cards.Contains(card))
+                {
+                    deckContents += cardString + Environment.NewLine;
+                    cards.Add(card);
 
-                Logger.Trace(namedLogSource, $"{card.DisplayName} added to batch ({CardCount}/{ConfigManager.BatchSize}).");
+                    Logger.Trace(namedLogSource, $"{card.DisplayName} added to batch ({CardCount}/{ConfigManager.BatchSize}).");
+                }
+                else
+                {
+                    Logger.Warn(namedLogSource, $"Batch already contains {card.DisplayName}");
+                }
             }
         }
 

--- a/HalfMagicProximity/ProximityManager.cs
+++ b/HalfMagicProximity/ProximityManager.cs
@@ -30,14 +30,16 @@
             rerenderAttempts = 0;
             renderingSketches = isSketch;
 
-            int batchEstimate = allCards.Count / ConfigManager.BatchSize + 1;
-            Logger.Info(LogSource, $"Splitting {allCards.Count} cards into an estimated {batchEstimate} batches.");
+            // Determine which cards are being rendered
+            List<CardData> cardsToRender = allCards;
+            if (renderingSketches)
+                cardsToRender = allCards.Where(x => x.Face == CardFace.Back && x.Layout == CardLayout.Adventure).ToList());
+
+            int batchEstimate = cardsToRender.Count / ConfigManager.BatchSize + 1;
+            Logger.Info(LogSource, $"Splitting {cardsToRender.Count} cards into an estimated {batchEstimate} batches.");
 
             // Sort cards into batches
-            if (renderingSketches)
-                CreateBatches(allCards.Where(x => x.Face == CardFace.Back && x.Layout == CardLayout.Adventure).ToList());
-            else
-                CreateBatches(allCards); // All cards to keep things in order to clear out proxies
+            CreateBatches(cardsToRender);
 
             // Run each batch in sequence
             for (int i = 0; i < batches.Count; i++)
@@ -96,7 +98,7 @@
 
             if (rerenderBatches.Count == rerenderAttempts)
                 rerenderBatches.Add(new ProximityBatch(this, RerenderBatchNameBase + rerenderAttempts, ProximityFileName, renderingSketches));
-            
+
             // Retry both front and back to be safe
             CardData[] cardsToRerender = allCards.Where(x => x.Name.ToLower().Contains(failedCard.ToLower())).ToArray();
 

--- a/HalfMagicProximity/ProximityManager.cs
+++ b/HalfMagicProximity/ProximityManager.cs
@@ -7,14 +7,14 @@
     {
         private const string LogSource = "ProximityManager";
         private const string ProximityFileName = "proximity-0.6.2.jar";
-        private const string BatchNameBase = "hlf_";
-        private const string RerenderBatchNameBase = BatchNameBase + "rerender_";
+        private string BatchNameBase => "hlf_" + (renderingSketches ? "sketch_" : "");
+        private string RerenderBatchNameBase => BatchNameBase + "rerender_";
 
         private List<CardData> allCards;
         private List<ProximityBatch> batches = new List<ProximityBatch>();
         private List<ProximityBatch> rerenderBatches = new List<ProximityBatch>();
 
-        private bool renderingSketches;
+        private bool renderingSketches = false;
 
         public ProximityManager(List<CardData> allCards)
         {

--- a/HalfMagicProximity/ProximityManager.cs
+++ b/HalfMagicProximity/ProximityManager.cs
@@ -33,7 +33,7 @@
             // Determine which cards are being rendered
             List<CardData> cardsToRender = allCards;
             if (renderingSketches)
-                cardsToRender = allCards.Where(x => x.Face == CardFace.Back && x.Layout == CardLayout.Adventure).ToList();
+                cardsToRender = allCards.Where(x => x.UseSketchTemplate).ToList();
 
             int batchEstimate = cardsToRender.Count / ConfigManager.BatchSize + 1;
             Logger.Info(LogSource, $"Splitting {cardsToRender.Count} cards into an estimated {batchEstimate} batches.");

--- a/HalfMagicProximity/ProximityManager.cs
+++ b/HalfMagicProximity/ProximityManager.cs
@@ -33,7 +33,7 @@
             // Determine which cards are being rendered
             List<CardData> cardsToRender = allCards;
             if (renderingSketches)
-                cardsToRender = allCards.Where(x => x.Face == CardFace.Back && x.Layout == CardLayout.Adventure).ToList());
+                cardsToRender = allCards.Where(x => x.Face == CardFace.Back && x.Layout == CardLayout.Adventure).ToList();
 
             int batchEstimate = cardsToRender.Count / ConfigManager.BatchSize + 1;
             Logger.Info(LogSource, $"Splitting {cardsToRender.Count} cards into an estimated {batchEstimate} batches.");

--- a/HalfMagicProximity/hlfconfig.json
+++ b/HalfMagicProximity/hlfconfig.json
@@ -14,12 +14,9 @@
 		"IsTraceEnabled_Instructions": "Enables more detailed trace logs. Not needed for most users.",
 		"IsTraceEnabled": false,
 
-		"DeleteBadFaces_Instructions": "Goes through the proxies created by Proximity and deletes the half that are unusable, then collects the good ones in the output directory.",
-		"DeleteBadFaces": true,
-
 		"UpdatesOnly_Instructions": "Checks for existing proxies in the output directory, and only processes new cards.",
 		"UpdatesOnly_Instructions_2": "If this is false, the output directory will be emptied of all images before running.",
-		"UpdatesOnly": true,
+		"UpdatesOnly": false,
 
 		"MaxRetries_Instructions": "How many retries the program will do for cards that fail to render properly in Proximity.",
 		"MaxRetries_Instructions_2": "Defaults to 3, which should be more than enough for small batch sizes.",
@@ -38,10 +35,10 @@
 		"ProxyRarityOverride": "uncommon",
 
 		"UseCardSubset_Instructions": "Only generate cards listed in 'CardSubset' option.",
-		"UseCardSubset": false,
+		"UseCardSubset": true,
 
 		"CardSubset_Instructions": "Add cards to this list and enable 'UseCardSubset' if you only want to generate a specific set of cards rather than the whole format.",
-		"CardSubset": [ "Fae of Wishes // Granted" ],
+		"CardSubset": [ "Altar of Bhaal // Bone Offering" ],
 
 		"IllegalSetCodes_Instructions": "Sets to filter out from the legal cards. Useful for Un cards and certain promos. Don't change unless you know what you're doing.'",
 		"IllegalSetCodes": [ "htr", "cmb" ],

--- a/HalfMagicProximity/hlfconfig.json
+++ b/HalfMagicProximity/hlfconfig.json
@@ -12,7 +12,7 @@
 		"ProximityDirectory": "",
 
 		"IsTraceEnabled_Instructions": "Enables more detailed trace logs. Not needed for most users.",
-		"IsTraceEnabled": false,
+		"IsTraceEnabled": true,
 
 		"UpdatesOnly_Instructions": "Checks for existing proxies in the output directory, and only processes new cards.",
 		"UpdatesOnly_Instructions_2": "If this is false, the output directory will be emptied of all images before running.",

--- a/HalfMagicProximity/hlfconfig.json
+++ b/HalfMagicProximity/hlfconfig.json
@@ -35,7 +35,7 @@
 		"ProxyRarityOverride": "uncommon",
 
 		"UseCardSubset_Instructions": "Only generate cards listed in 'CardSubset' option.",
-		"UseCardSubset": true,
+		"UseCardSubset": false,
 
 		"CardSubset_Instructions": "Add cards to this list and enable 'UseCardSubset' if you only want to generate a specific set of cards rather than the whole format.",
 		"CardSubset": [ "Altar of Bhaal // Bone Offering" ],


### PR DESCRIPTION
[Added Sketch template](https://trello.com/c/BG8N8Ggm) for use with the back sides of Adventure cards. This makes them easier to distinguish from the front half when there's no alternate art available.

![Young Blue Dragon](https://user-images.githubusercontent.com/102198704/170826698-8393fa46-754c-4b0d-a66b-d608d6600fce.png)
![Sand Augury](https://user-images.githubusercontent.com/102198704/170826705-faecc144-21ae-4948-9db3-07b9935e759c.png)

Additional Fixes:
- Fixed a [bug](https://trello.com/c/qL8mV5EF) where repeated failed renders were re-added to the list exponentially
- Updated JSON for Baldur's Gate and pulled art crops for new adventures
- Note: Had to remove the config option to prevent cleaning up proxies in order to cleanly generate the two different templates