### PR TITLE
Aftermath template

### DIFF
--- a/HalfMagicProximity/App.cs
+++ b/HalfMagicProximity/App.cs
@@ -20,12 +20,16 @@ namespace HalfMagicProximity
                 ArtManager artManager = new ArtManager(cardManager.Cards);
 
                 // Generate the front faces of adventures and all split cards with the normal M15 template
-                proximityManager.Run(isSketch:false);
-                artManager.CleanProxies(isSketch: false);
+                proximityManager.Run(CardTemplate.M15);
+                artManager.CleanProxies(CardTemplate.M15);
 
                 // Generate the back faces of adventures with the sketch template
-                proximityManager.Run(isSketch:true);
-                artManager.CleanProxies(isSketch:true);
+                proximityManager.Run(CardTemplate.Sketch);
+                artManager.CleanProxies(CardTemplate.Sketch);
+
+                // Generate the back faces of aftermath cards with the double feature template
+                proximityManager.Run(CardTemplate.DoubleFeature);
+                artManager.CleanProxies(CardTemplate.DoubleFeature);
 
                 TimeSpan elapsed = timer.Elapsed;
                 string elapsedString = string.Format("{0:00}:{1:00}.{2:00}", elapsed.Minutes, elapsed.Seconds, elapsed.Milliseconds / 10);

--- a/HalfMagicProximity/ArtManager.cs
+++ b/HalfMagicProximity/ArtManager.cs
@@ -17,7 +17,7 @@ namespace HalfMagicProximity
             this.cards = cards ?? throw new ArgumentNullException(nameof(cards));
         }
 
-        public void CleanProxies(bool isSketch = false)
+        public void CleanProxies(CardTemplate template)
         {
             string executingDirectory = GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             string outputDirectory = ConfigManager.OutputDirectory;
@@ -31,11 +31,14 @@ namespace HalfMagicProximity
 
                     Logger.Trace(LogSource, $"Created output directory: {outputDirectory}");
 
-                    if (isSketch)
+                    if (template == CardTemplate.Sketch)
                         Logger.Warn(LogSource, $"All non sketch proxies possibly missing from output directory: {outputDirectory}");
+                    else if (template == CardTemplate.DoubleFeature)
+                        Logger.Warn(LogSource, $"All non double feature proxies possibly missing from output directory: {outputDirectory}");
                 }
-                else if (!ConfigManager.UpdatesOnly && !isSketch)
+                else if (!ConfigManager.UpdatesOnly && template == CardTemplate.M15)
                 {
+                    // Normal frame cards get generated first, so only clear the folder the first time this is called
                     Logger.Warn(LogSource, $"Clearing output directory of all '.png' files: {outputDirectory}");
 
                     foreach (string filePath in Directory.EnumerateFiles(outputDirectory))
@@ -89,13 +92,19 @@ namespace HalfMagicProximity
                             if (cardData != null)
                             {
                                 bool deleteProxy = false;
-                                if (!isSketch)
+                                if (template == CardTemplate.M15)
                                 {
-                                    if (cardData.UseSketchTemplate)
+                                    if (cardData.Template == CardTemplate.Sketch)
                                     {
                                         // Ignore all adventure backs if we're not pulling sketches
                                         deleteProxy = true;
                                         Logger.Trace(LogSource, $"Skipping normal proxy for adventure backs. Wait for a sketch proxy.");
+                                    }
+                                    else if (cardData.Template == CardTemplate.Sketch)
+                                    {
+                                        // Ignore all adventure backs if we're not pulling sketches
+                                        deleteProxy = true;
+                                        Logger.Trace(LogSource, $"Skipping normal proxy for aftermath backs. Wait for a double feature proxy.");
                                     }
                                     else
                                     {
@@ -109,11 +118,11 @@ namespace HalfMagicProximity
                                 }
                                 else
                                 {
-                                    // We want to copy over all sketch backs regardless of number, and delete all fronts
+                                    // We want to copy over all sketch and double feature backs regardless of number, and delete all fronts
                                     deleteProxy = cardData.Face == CardFace.Front;
 
                                     if (deleteProxy)
-                                        Logger.Trace(LogSource, $"Deleting proxy because it's a sketch front. Sketch frame is only used for adventure backs.");
+                                        Logger.Trace(LogSource, $"Deleting proxy because it's a sketch or double feature front. These frames are only used for card backs.");
                                 }
 
                                 // Copy good proxies to the output directory and rename them without the proximity render number in front
@@ -123,8 +132,8 @@ namespace HalfMagicProximity
                                     string goodProxyPath = Path.Combine(outputDirectory, cardName + ExpectedExtension);
 
                                     // If we haven't made a proxy of this card yet then make one, otherwise ignore it
-                                    // Always copy and overwrite good sketches
-                                    if ((!File.Exists(goodProxyPath) && !isSketch) || isSketch)
+                                    // Always copy and overwrite good sketches and double features
+                                    if ((!File.Exists(goodProxyPath) && template == CardTemplate.M15) || template != CardTemplate.M15)
                                     {
                                         File.Copy(proxyFilePath, goodProxyPath, true);
 
@@ -179,7 +188,7 @@ namespace HalfMagicProximity
                 foreach (CardData thisCard in cards)
                 {
                     // Don't want to report cards that are generated with a different template
-                    if (!File.Exists(Path.Combine(outputDirectory, thisCard.DisplayName + ExpectedExtension)) && isSketch == thisCard.UseSketchTemplate)
+                    if (!File.Exists(Path.Combine(outputDirectory, thisCard.DisplayName + ExpectedExtension)) && template == thisCard.Template)
                     {
                         Logger.Warn(LogSource, $"No proxy found for {thisCard.DisplayName}.");
                         failedProxies++;

--- a/HalfMagicProximity/ArtManager.cs
+++ b/HalfMagicProximity/ArtManager.cs
@@ -31,6 +31,7 @@ namespace HalfMagicProximity
 
                     Logger.Trace(LogSource, $"Created output directory: {outputDirectory}");
 
+                    // M15 template is generated first, so if the output directory is being created on a different template, something likely went wrong earlier in the process
                     if (template == CardTemplate.Sketch)
                         Logger.Warn(LogSource, $"All non sketch proxies possibly missing from output directory: {outputDirectory}");
                     else if (template == CardTemplate.DoubleFeature)
@@ -139,7 +140,7 @@ namespace HalfMagicProximity
 
                                         if (File.Exists(goodProxyPath))
                                         {
-                                            Logger.Debug(LogSource, $"Good proxy for {cardName} copied to '{goodProxyPath}'.");
+                                            Logger.Debug(LogSource, $"Good proxy for {cardName} copied to output directory.");
                                             goodProxyCount++;
                                         }
                                         else

--- a/HalfMagicProximity/CardData.cs
+++ b/HalfMagicProximity/CardData.cs
@@ -1,7 +1,8 @@
 ﻿namespace HalfMagicProximity
 {
-    public enum CardFace { Front, Back };
-    public enum CardLayout { Split, Adventure, None };
+    public enum CardFace { Front, Back, };
+    public enum CardLayout { Split, Adventure, };
+    public enum CardTemplate { M15, Sketch, DoubleFeature, };
 
     /// <summary>
     /// A card pulled from the Scryfall JSON
@@ -20,6 +21,7 @@
         private bool manualArtist = false;
         public CardFace Face { get; private set; }
         public CardLayout Layout { get; private set; }
+        public CardTemplate Template { get; private set; }
         public CardData OtherFace { get; set; }
         public string Watermark { get; private set; }
 
@@ -28,10 +30,7 @@
         public bool NeedsArtistOverride => Artist != OtherFace.Artist || manualArtist;
         public bool NeedsWatermarkOverride => !string.IsNullOrEmpty(Watermark) || !string.IsNullOrEmpty(OtherFace.Watermark);
 
-        // All Adventure Backs (ie. the actual adventure spell) are generated with a different template from their fronts and split cards
-        public bool UseSketchTemplate => Face == CardFace.Back && Layout == CardLayout.Adventure;
-
-        public CardData(string name, string manaCost, string art, string artist, CardFace face, CardLayout layout, string watermark)
+        public CardData(string name, string manaCost, string art, string artist, CardFace face, CardLayout layout, CardTemplate template, string watermark)
         {
             if (string.IsNullOrEmpty(name))
                 Logger.Warn(LogSource, "Card object created with no name!");
@@ -54,10 +53,10 @@
             if (string.IsNullOrEmpty(artist))
                 Logger.Warn(namedLogSource, "Card object created with no artist name!");
             Artist = artist;
-
-            if (layout == CardLayout.None)
-                Logger.Warn(namedLogSource, "Card object created with no layout!");
+            
+            // Don't need to check for empty layout/template, they have default values
             Layout = layout;
+            Template = template;
 
             // Don't need to check if watermark is empty, empty indicates no watermark
             Watermark = watermark;

--- a/HalfMagicProximity/ConfigManager.cs
+++ b/HalfMagicProximity/ConfigManager.cs
@@ -149,7 +149,7 @@ namespace HalfMagicProximity
             }
             catch
             {
-                Logger.Warn(LogSource, $"Invalid batch size supplied. Defaulting to {defaultMaxRetries}.");
+                Logger.Warn(LogSource, $"Invalid batch size supplied. Defaulting to {defaultBatchSize}.");
                 BatchSize = defaultBatchSize;
             }
         }
@@ -474,7 +474,7 @@ namespace HalfMagicProximity
             if (UpdatesOnly)
                 Logger.Debug(LogSource, $"Only new cards will be rendered.");
             else
-                Logger.Warn(LogSource, $"All possible cards will be rendered.");
+                Logger.Warn(LogSource, $"All possible cards will be rendered, not only new cards.");
         }
 
         /// <summary>

--- a/HalfMagicProximity/ProximityBatch.cs
+++ b/HalfMagicProximity/ProximityBatch.cs
@@ -26,6 +26,7 @@ namespace HalfMagicProximity
         private string proximityPath => Path.Combine(ConfigManager.ProximityDirectory, proximityFile);
         private const string hlfTemplateFile = "hlf.zip";
         private const string sketchTemplateFile = "hlfsketch.zip";
+        private const string doubleFeatureTemplateFile = "hlfdoublefeature.zip";
         private string templateFile;
         private string templatePath => Path.Combine(ConfigManager.ProximityDirectory, "templates", templateFile);
 
@@ -34,7 +35,7 @@ namespace HalfMagicProximity
         public bool IsFull => CardCount >= ConfigManager.BatchSize;
         public bool IsBatchFunctional => !string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(proximityFile) && CardCount > 0;
 
-        public ProximityBatch(ProximityManager manager, string name, string prox, bool isSketch)
+        public ProximityBatch(ProximityManager manager, string name, string prox, CardTemplate cardTemplate)
         {
             this.manager = manager ?? throw new ArgumentNullException(nameof(manager));
 
@@ -48,10 +49,19 @@ namespace HalfMagicProximity
             else
                 proximityFile = prox;
 
-            if (isSketch)
-                templateFile = sketchTemplateFile;
-            else
-                templateFile = hlfTemplateFile;
+            switch (cardTemplate)
+            {
+                case CardTemplate.Sketch:
+                    templateFile = sketchTemplateFile;
+                    break;
+                case CardTemplate.DoubleFeature:
+                    templateFile = doubleFeatureTemplateFile;
+                    break;
+                case CardTemplate.M15:
+                default:
+                    templateFile = hlfTemplateFile;
+                    break;
+            }
 
             Logger.Trace(namedLogSource, $"Batch {this.name} successfully created.");
         }

--- a/HalfMagicProximity/ProximityManager.cs
+++ b/HalfMagicProximity/ProximityManager.cs
@@ -30,7 +30,6 @@
         private List<ProximityBatch> rerenderBatches = new List<ProximityBatch>();
 
         private CardTemplate currentTemplate = CardTemplate.M15;
-        private bool renderingDouble = false;
 
         public ProximityManager(List<CardData> allCards)
         {

--- a/HalfMagicProximity/hlfconfig.json
+++ b/HalfMagicProximity/hlfconfig.json
@@ -12,7 +12,7 @@
 		"ProximityDirectory": "",
 
 		"IsTraceEnabled_Instructions": "Enables more detailed trace logs. Not needed for most users.",
-		"IsTraceEnabled": true,
+		"IsTraceEnabled": false,
 
 		"UpdatesOnly_Instructions": "Checks for existing proxies in the output directory, and only processes new cards.",
 		"UpdatesOnly_Instructions_2": "If this is false, the output directory will be emptied of all images before running.",
@@ -35,167 +35,18 @@
 		"ProxyRarityOverride": "uncommon",
 
 		"UseCardSubset_Instructions": "Only generate cards listed in 'CardSubset' option.",
-		"UseCardSubset": false,
+		"UseCardSubset": true,
 
 		"CardSubset_Instructions": "Add cards to this list and enable 'UseCardSubset' if you only want to generate a specific set of cards rather than the whole format.",
-		"CardSubset": [ "Fae of Wishes // Granted" ],
+		"CardSubset": [ "Appeal // Authority" ],
 
 		"IllegalSetCodes_Instructions": "Sets to filter out from the legal cards. Useful for Un cards and certain promos. Don't change unless you know what you're doing.'",
 		"IllegalSetCodes": [ "htr", "cmb" ],
 
 		"ManualArtistOverrides_Instructions": "List cards here that need artists manually assigned.",
-		"ManualArtistOverrides_Instructions_2": "This will mostly be the back side of adventure cards, as well as any card with two arists credited for the same piece.",
+		"ManualArtistOverrides_Instructions_2": "This will mostly be the back side of adventure cards if generated with alternate art.",
+		"ManualArtistOverrides_Instructions_3": "Also includes any card with two arists credited for the same piece.",
 		"ManualArtistOverrides": [
-			{
-				"card": "Animating Faerie // Bring to Life",
-				"face": "Back",
-				"artist": "Chris Seaman"
-			},
-			{
-				"card": "Ardenvale Tactician // Dizzying Swoop",
-				"face": "Back",
-				"artist": "Aaron Miller"
-			},
-			{
-				"card": "Beanstalk Giant // Fertile Footsteps",
-				"face": "Back",
-				"artist": "Nick Southam"
-			},
-			{
-				"card": "Bonecrusher Giant // Stomp",
-				"face": "Back",
-				"artist": "John Severin Brassell"
-			},
-			{
-				"card": "Brazen Borrower // Petty Theft",
-				"face": "Back",
-				"artist": "Iris Compiet"
-			},
-			{
-				"card": "Curious Pair // Treats to Share",
-				"face": "Back",
-				"artist": "Josu Hernaiz"
-			},
-			{
-				"card": "Embereth Shieldbreaker // Battle Display",
-				"face": "Back",
-				"artist": "Jeremy Wilson"
-			},
-			{
-				"card": "Fae of Wishes // Granted",
-				"face": "Back",
-				"artist": "Wylie Beckert"
-			},
-			{
-				"card": "Faerie Guidemother // Gift of the Fae",
-				"face": "Back",
-				"artist": "Chuck Lukacs"
-			},
-			{
-				"card": "Flaxen Intruder // Welcome Home",
-				"face": "Back",
-				"artist": "Omar Rayyan"
-			},
-			{
-				"card": "Foulmire Knight // Profane Insight",
-				"face": "Back",
-				"artist": "Rebecca On"
-			},
-			{
-				"card": "Garenbrig Carver // Shield's Might",
-				"face": "Back",
-				"artist": "Craig J. Spearing"
-			},
-			{
-				"card": "Giant Killer // Chop Down",
-				"face": "Back",
-				"artist": "Shawn Wood"
-			},
-			{
-				"card": "Hypnotic Sprite // Mesmeric Glare",
-				"face": "Back",
-				"artist": "Ravenna Tran"
-			},
-			{
-				"card": "Lonesome Unicorn // Rider in Need",
-				"face": "Back",
-				"artist": "Alayna Danner"
-			},
-			{
-				"card": "Lovestruck Beast // Heart's Desire",
-				"face": "Back",
-				"artist": "Tyler Walpole"
-			},
-			{
-				"card": "Merchant of the Vale // Haggle",
-				"face": "Back",
-				"artist": "John Severin Brassell"
-			},
-			{
-				"card": "Merfolk Secretkeeper // Venture Deeper",
-				"face": "Back",
-				"artist": "Allen Williams"
-			},
-			{
-				"card": "Murderous Rider // Swift End",
-				"face": "Back",
-				"artist": "Ravenna Tran"
-			},
-			{
-				"card": "Oakhame Ranger // Bring Back",
-				"face": "Back",
-				"artist": "Omar Rayyan"
-			},
-			{
-				"card": "Order of Midnight // Alter Fate",
-				"face": "Back",
-				"artist": "Seb McKinnon"
-			},
-			{
-				"card": "Queen of Ice // Rage of Winter",
-				"face": "Back",
-				"artist": "Allen Williams"
-			},
-			{
-				"card": "Realm-Cloaked Giant // Cast Off",
-				"face": "Back",
-				"artist": "Alayna Danner"
-			},
-			{
-				"card": "Reaper of Night // Harvest Fear",
-				"face": "Back",
-				"artist": "Olena Richards"
-			},
-			{
-				"card": "Rimrock Knight // Boulder Rush",
-				"face": "Back",
-				"artist": "Josu Hernaiz"
-			},
-			{
-				"card": "Rosethorn Acolyte // Seasonal Ritual",
-				"face": "Back",
-				"artist": "Wylie Beckert"
-			},
-			{
-				"card": "Shepherd of the Flock // Usher to Safety",
-				"face": "Back",
-				"artist": "Craig J. Spearing"
-			},
-			{
-				"card": "Silverflame Squire // On Alert",
-				"face": "Back",
-				"artist": "Josu Hernaiz"
-			},
-			{
-				"card": "Smitten Swordmaster // Curry Favor",
-				"face": "Back",
-				"artist": "Shawn Wood"
-			},
-			{
-				"card": "Tuinvale Treefolk // Oaken Boon",
-				"face": "Back",
-				"artist": "James Arnold"
-			},
 			{
 				"card": "Hide // Seek",
 				"face": "Front",

--- a/HalfMagicProximity/hlfconfig.json
+++ b/HalfMagicProximity/hlfconfig.json
@@ -35,7 +35,7 @@
 		"ProxyRarityOverride": "uncommon",
 
 		"UseCardSubset_Instructions": "Only generate cards listed in 'CardSubset' option.",
-		"UseCardSubset": true,
+		"UseCardSubset": false,
 
 		"CardSubset_Instructions": "Add cards to this list and enable 'UseCardSubset' if you only want to generate a specific set of cards rather than the whole format.",
 		"CardSubset": [ "Appeal // Authority" ],
@@ -66,6 +66,156 @@
 				"card": "Trial // Error",
 				"face": "Back",
 				"artist": "Ron Spears & Wayne Reynolds"
+			},
+			{
+				"card": "Animating Faerie // Bring to Life",
+				"face": "Back",
+				"artist": "Chris Seaman"
+			},
+			{
+				"card": "Ardenvale Tactician // Dizzying Swoop",
+				"face": "Back",
+				"artist": "Aaron Miller"
+			},
+			{
+				"card": "Beanstalk Giant // Fertile Footsteps",
+				"face": "Back",
+				"artist": "Nick Southam"
+			},
+			{
+				"card": "Bonecrusher Giant // Stomp",
+				"face": "Back",
+				"artist": "John Severin Brassell"
+			},
+			{
+				"card": "Brazen Borrower // Petty Theft",
+				"face": "Back",
+				"artist": "Iris Compiet"
+			},
+			{
+				"card": "Curious Pair // Treats to Share",
+				"face": "Back",
+				"artist": "Josu Hernaiz"
+			},
+			{
+				"card": "Embereth Shieldbreaker // Battle Display",
+				"face": "Back",
+				"artist": "Jeremy Wilson"
+			},
+			{
+				"card": "Fae of Wishes // Granted",
+				"face": "Back",
+				"artist": "Wylie Beckert"
+			},
+			{
+				"card": "Faerie Guidemother // Gift of the Fae",
+				"face": "Back",
+				"artist": "Chuck Lukacs"
+			},
+			{
+				"card": "Flaxen Intruder // Welcome Home",
+				"face": "Back",
+				"artist": "Omar Rayyan"
+			},
+			{
+				"card": "Foulmire Knight // Profane Insight",
+				"face": "Back",
+				"artist": "Rebecca On"
+			},
+			{
+				"card": "Garenbrig Carver // Shield's Might",
+				"face": "Back",
+				"artist": "Craig J. Spearing"
+			},
+			{
+				"card": "Giant Killer // Chop Down",
+				"face": "Back",
+				"artist": "Shawn Wood"
+			},
+			{
+				"card": "Hypnotic Sprite // Mesmeric Glare",
+				"face": "Back",
+				"artist": "Ravenna Tran"
+			},
+			{
+				"card": "Lonesome Unicorn // Rider in Need",
+				"face": "Back",
+				"artist": "Alayna Danner"
+			},
+			{
+				"card": "Lovestruck Beast // Heart's Desire",
+				"face": "Back",
+				"artist": "Tyler Walpole"
+			},
+			{
+				"card": "Merchant of the Vale // Haggle",
+				"face": "Back",
+				"artist": "John Severin Brassell"
+			},
+			{
+				"card": "Merfolk Secretkeeper // Venture Deeper",
+				"face": "Back",
+				"artist": "Allen Williams"
+			},
+			{
+				"card": "Murderous Rider // Swift End",
+				"face": "Back",
+				"artist": "Ravenna Tran"
+			},
+			{
+				"card": "Oakhame Ranger // Bring Back",
+				"face": "Back",
+				"artist": "Omar Rayyan"
+			},
+			{
+				"card": "Order of Midnight // Alter Fate",
+				"face": "Back",
+				"artist": "Seb McKinnon"
+			},
+			{
+				"card": "Queen of Ice // Rage of Winter",
+				"face": "Back",
+				"artist": "Allen Williams"
+			},
+			{
+				"card": "Realm-Cloaked Giant // Cast Off",
+				"face": "Back",
+				"artist": "Alayna Danner"
+			},
+			{
+				"card": "Reaper of Night // Harvest Fear",
+				"face": "Back",
+				"artist": "Olena Richards"
+			},
+			{
+				"card": "Rimrock Knight // Boulder Rush",
+				"face": "Back",
+				"artist": "Josu Hernaiz"
+			},
+			{
+				"card": "Rosethorn Acolyte // Seasonal Ritual",
+				"face": "Back",
+				"artist": "Wylie Beckert"
+			},
+			{
+				"card": "Shepherd of the Flock // Usher to Safety",
+				"face": "Back",
+				"artist": "Craig J. Spearing"
+			},
+			{
+				"card": "Silverflame Squire // On Alert",
+				"face": "Back",
+				"artist": "Josu Hernaiz"
+			},
+			{
+				"card": "Smitten Swordmaster // Curry Favor",
+				"face": "Back",
+				"artist": "Shawn Wood"
+			},
+			{
+				"card": "Tuinvale Treefolk // Oaken Boon",
+				"face": "Back",
+				"artist": "James Arnold"
 			}
 		]
 	}


### PR DESCRIPTION
Implementing a Double Feature template to make Aftermath cards more distinct.
- Required refactoring to make sketch behaviors generic
- Cards now have a Template property that is assigned on creation to determine how it should be rendered
- Filtering out Alchemy cards, since they're separate cards from their non alchemy counterparts

[Trello Card](https://trello.com/c/pvemtNQ9)